### PR TITLE
upgraded devices are 'non legacy routers'

### DIFF
--- a/ff_net_worth_calculator/data/devices.json
+++ b/ff_net_worth_calculator/data/devices.json
@@ -17,6 +17,7 @@
   {"name": "TP-Link TL-WA830", "price": 25, "legacy": true},
   {"name": "TP-Link TL-WA850", "price": 30, "legacy": true},
   {"name": "TP-Link TL-WA860", "price": 30, "legacy": true},
+  {"name": "TP-Link TL-WR841N/ND Mod", "price": 17, "legacy": false},
   {"name": "TP-Link TL-WR841", "price": 15, "legacy": true},
   {"name": "TP-Link TL-WR843", "price": 20, "legacy": true},
   {"name": "TP-Link TL-WR842N/ND v1", "price": 25, "legacy": true},


### PR DESCRIPTION
Hanover has a huge amount of TP-Links TL-WR841 in various revisions.
Though we make sure, they are not becoming more - anymore;
dumping them all has been considered a huge waste of resources.

@CodeFetch has put significant effort in providing [detailed information](https://www.heise.de/select/ct/2019/14/1561986310067151) on sparing them as long as possible, with a reasonable amount of effort.

His effort has been recognized by us providing firmware which marks them as `TL-WR841N/ND Mod` which in turn improves hanovers statistics by 1695€.

